### PR TITLE
use `esModuleInterop` instead of `allowSyntheticDefaultImports` to allow cjs `require` works

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
       "rootDir": "./src",
       "strict": true,
-      "allowSyntheticDefaultImports": true
+      "esModuleInterop": true
     },
     "include": ["src/index.ts"],
     "exclude": ["node_modules"]


### PR DESCRIPTION
In short, the following code throws an error:
```typescript
// For CommonJS
const { FileSystemAsyncLoader } = require('nunjucks-async-loader');

const loader = new FileSystemAsyncLoader('views', {
});
```
error: 
```text
.../nunjucks-async-loader/dist/cjs/index.cjs:26
            searchPaths = searchPaths.map(node_path_1.default.normalize);
                                                              ^

TypeError: Cannot read properties of undefined (reading 'normalize')
    at new FileSystemAsyncLoader (.../nunjucks-async-loader/dist/cjs/index.cjs:26:63)
    at Object.<anonymous> (.../index.js:4:16)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47

Node.js v18.16.0

```

The reason is that the compiled code directly uses "require('node:path').default.normalize".

We need to enable 'esModuleInterop' to make 'tsc' do some  "polyfill " for us.
The final build looks like this:
```typescript
var __importDefault = (this && this.__importDefault) || function (mod) {
    return (mod && mod.__esModule) ? mod : { "default": mod };
};
__importDefault(require("node:path")).default.normalize
```
